### PR TITLE
Fixed initialization error

### DIFF
--- a/rqg.html
+++ b/rqg.html
@@ -3,7 +3,6 @@
 <html lang="en">
     <head>
         <link rel="stylesheet" href="rqg.css">
-        <script src="rqg.js"></script>
     </head>
 
     <body>
@@ -26,5 +25,6 @@
               <a class="twitter button" id="js-tweet" target="_blank" rel="noreferrer">Tweet it!</a>
             </section>
           </div>
+          <script src="rqg.js"></script>
     </body>
 </html>


### PR DESCRIPTION
When the `script` tag is put in the `head` section of the document, DOM access (e.g. `document.querySelector(...)`) must be wrapped in a callback passed to the [`DOMContentLoaded`](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event) event. However, it's better to put JavaScript [at the bottom of the `body` element](https://stackoverflow.com/questions/436411/where-should-i-put-script-tags-in-html-markup). This is called [progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement). 😊